### PR TITLE
Update photos to load thumbnail versions

### DIFF
--- a/src/Components/Photo.tsx
+++ b/src/Components/Photo.tsx
@@ -20,7 +20,7 @@ const Photo = (props: Props) => {
   return (
     <Grow in={visible}>
       <img
-        src={props.photo.link}
+        src={props.photo.link.replace('.jpg', 'l.jpg')}
         alt={props.photo.description}
         onLoad={imageLoaded}
         style={{ 

--- a/src/Components/Sections/Photos.tsx
+++ b/src/Components/Sections/Photos.tsx
@@ -4,24 +4,45 @@ import { useEffect, useState } from "react";
 
 import Photo from '../Photo';
 
+type ImgurResponse = {
+  data: {
+    images: [{
+      link: string,
+      description: string
+    }]
+  }
+}
+
 const Photos: React.FunctionComponent = () => {
   const [visible, setVisible] = useState(false);
-  const [images, setImages] = useState([]);
+  const [wait, setWait] = useState(true);
+  const [response, setResponse] = useState<ImgurResponse>();
 
+  // Get the API response
   useEffect(() => {
     setVisible(true);
 
     fetch("https://api.imgur.com/3/album/JKELiQA", { headers: { Authorization: 'CLIENT-ID ' + process.env.REACT_APP_IMGUR_API_KEY } })
       .then(res => res.json())
-      .then(result => setImages(result.data.images));
+      .then(result => setResponse(result));
+  }, []);
+
+  // Wait 1 second before allowing the error to display, to prevent it displaying in the gap of time
+  // where the image data is being fetched
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setWait(false);
+    }, 1000);
+
+    return () => clearTimeout(timer);
   }, []);
 
   return (
     <Fade in={visible} mountOnEnter unmountOnExit>
       <Container maxWidth="xl" style={{ textAlign: 'center' }}>
-        {images !== undefined ? images.map((img, i) => (
+        {response !== undefined ? response.data.images.map((img, i) => (
           <Photo key={i} photo={img} />
-        )) :
+        )) : wait ? '' :
           <Snackbar open={true} autoHideDuration={6000} style={{bottom: '5vh'}}>
             <Alert severity='error'>Images Failed to Load!</Alert>
           </Snackbar>


### PR DESCRIPTION
closes #20 

- Set the photos to load using thumbnail variants rather than full sized images, improving the load time of each image drastically. 
- Add more typescript declarations to the Photos page and API responses
- Wait 1 second before displaying the load failure error message, to prevent it being opened when the images are being fetched 