### PR TITLE
#21 video grow in

### DIFF
--- a/src/Components/Elements/Video.tsx
+++ b/src/Components/Elements/Video.tsx
@@ -1,0 +1,50 @@
+import { Divider, Hidden, Typography, Fade, Box } from '@material-ui/core'
+import ReactPlayer from 'react-player';
+import useWindowSize from '../../hooks/useWindowSize';
+import { useState } from 'react';
+
+import { VideoType } from './../../types';
+import { Skeleton } from '@material-ui/lab';
+
+const Video: React.FunctionComponent<VideoType> = (props) => {
+  const windowSize = useWindowSize();
+  const [loading, setLoading] = useState(true);
+
+  return (
+    <>
+      <Typography 
+        variant={windowSize.width >= 960 ? 'h4' : 'h6' } 
+        style={{ fontFamily: 'Josefin Sans', textAlign: 'center', paddingBottom: '2vh' }}
+      >
+        {props.snippet.title}
+      </Typography>
+      <Hidden smDown>
+        <Typography style={{ paddingBottom: '2vh' }}>{props.snippet.description.split('\n')[0]}</Typography>
+      </Hidden>
+      {loading ?
+        <Skeleton variant='rect'
+          width={windowSize.width >= 960 ? 960 : '90vw'}
+          height={windowSize.width >= 960 ? 540 : windowSize.width * .9 * (9 / 16)}
+        /> : null}
+      <Fade in={!loading} timeout={1000}>
+        <Box>
+          {/* 
+            The height needs to be set to 0 in order to not take up double the space with the skeleton and the video,
+            however if both are set to 0 before the load, the thumbnail fetched will be the lowest resolution available,
+            as it seems thumbnail fetching is dynamic to the player's size, so width NEEDS to remain constant, to fetch 
+            thumbnails at the required size
+          */}
+          <ReactPlayer url={`https://www.youtube.com/watch?v=${props.snippet.resourceId.videoId}`} controls
+            width={windowSize.width >= 960 ? 912 : '90vw'}
+            height={loading ? 0 : windowSize.width >= 960 ? 513 : windowSize.width * .9 * (9 / 16)}
+            onReady={() => setLoading(false)}
+          />
+        </Box>
+      </Fade>
+
+      <Divider style={{ margin: 50 }} />
+    </>
+  )
+}
+
+export default Video;

--- a/src/Components/Sections/Software.tsx
+++ b/src/Components/Sections/Software.tsx
@@ -17,7 +17,7 @@ const Software: React.FunctionComponent = () => {
   }, []);
 
   return (
-    <Fade in={visible}>
+    <Fade in={visible} mountOnEnter unmountOnExit timeout={700}>
       <Container maxWidth="md">
         <Grid container spacing={3}>
           {repos !== undefined ?

--- a/src/Components/Sections/Videos.tsx
+++ b/src/Components/Sections/Videos.tsx
@@ -1,18 +1,14 @@
-import { Container, Divider, Fade, Hidden, Typography, Snackbar } from '@material-ui/core'
+import { Container, Fade, Snackbar } from '@material-ui/core'
 import Alert from "@material-ui/lab/Alert";
-import { useEffect, useState, Fragment } from 'react';
-import ReactPlayer from 'react-player';
-import useWindowSize from '../../hooks/useWindowSize';
+import { useEffect, useState } from 'react';
 
-type VideoAPIResponse = {
-  snippet: { description: string, title: string, resourceId: {videoId: string} }
-}
+import { VideoType } from './../../types';
+
+import Video from './../Elements/Video';
 
 const Videos: React.FunctionComponent = () => {
   const [visible, setVisible] = useState(false);
-  const windowSize = useWindowSize();
-
-  const [videos, setVideos] = useState<VideoAPIResponse[]>([]);
+  const [videos, setVideos] = useState<VideoType[]>([]);
 
   useEffect(() => {
     setVisible(true);
@@ -23,21 +19,10 @@ const Videos: React.FunctionComponent = () => {
   }, [])
 
   return (
-    <Fade in={visible}>
+    <Fade in={visible} mountOnEnter unmountOnExit timeout={1000}>
       <Container maxWidth='md'>
         {videos !== undefined ? videos.map(vid => (
-          <Fragment>
-            <Typography variant='h4' style={{ fontFamily: 'Josefin Sans', textAlign: 'center', paddingBottom: '2vh' }}>{vid.snippet.title}</Typography>
-            <Hidden smDown>
-              <Typography style={{paddingBottom: '2vh'}}>{vid.snippet.description.split('\n')[0]}</Typography>
-            </Hidden>
-            <ReactPlayer url={`https://www.youtube.com/watch?v=${vid.snippet.resourceId.videoId}`} controls
-              width={windowSize.width >= 960 ? 960 : '90vw'}
-              height={windowSize.width >= 960 ? 540 : windowSize.width * .9 * (9 / 16)}
-            />
-
-            <Divider style={{ margin: 50 }} />
-          </Fragment>
+         <Video {...vid} />
         )) :  
         <Snackbar open={true} autoHideDuration={6000} style={{bottom: '5vh'}}>
           <Alert severity='error'>Videos Failed to Load!</Alert>

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,3 +16,7 @@ export type PhotoType = {
   link: string,
   description: string
 }
+
+export type VideoType = {
+  snippet: { description: string, title: string, resourceId: {videoId: string} }
+}


### PR DESCRIPTION
closes #21 

Added skeleton loading to the video players, adjusted the formatting to be correct, and set the page loading to fade in on every page, rather than just some.